### PR TITLE
Add command history

### DIFF
--- a/src/main/java/seedu/address/commons/util/AudioUtil.java
+++ b/src/main/java/seedu/address/commons/util/AudioUtil.java
@@ -1,0 +1,21 @@
+package seedu.address.commons.util;
+
+import java.io.File;
+
+import javafx.scene.media.Media;
+import javafx.scene.media.MediaPlayer;
+/**
+ * Contains auto-specific code
+ */
+public class AudioUtil {
+    /**
+     * Plays an audio given a file path. Note that there is a slight delay due to having to load up the media player
+     *
+     * @param audioPath File path to the audio file to play. Note that directory starts from project root
+     */
+    public static void playAudio(String audioPath) {
+        Media media = new Media(new File(audioPath).toURI().toString());
+        MediaPlayer mediaPlayer = new MediaPlayer(media);
+        mediaPlayer.play();
+    }
+}

--- a/src/main/java/seedu/address/commons/util/UiUtil.java
+++ b/src/main/java/seedu/address/commons/util/UiUtil.java
@@ -1,0 +1,40 @@
+package seedu.address.commons.util;
+
+import javafx.scene.control.TextInputControl;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.Region;
+
+import java.util.function.Consumer;
+
+/**
+ * This class contains JavaFX-specific tasks
+ */
+public class UiUtil {
+
+    /**
+     * Creates a keyboard shortcut
+     * @param region Obtained by calling getRoot() inside JavaFX code
+     * @param keyCode The specific key code you want to use as a shortcut
+     * @param func The function to execute upon triggering
+     */
+    public static void setShortcut(Region region, KeyCode keyCode, Consumer<KeyEvent> func) {
+        region.addEventFilter(KeyEvent.KEY_PRESSED, event -> {
+            if (event.getCode() == keyCode) {
+                event.consume(); // This stops the event from doing what it would otherwise do without this function
+                func.accept(event);
+            }
+        });
+    }
+
+    /**
+     * Sets the text of an input. This abstracts away the logic of setting the position caret manually
+     * @param textInput Text input to modify
+     * @param text Text to set
+     */
+    public static void setText(TextInputControl textInput, String text) {
+        textInput.setText(text);
+        textInput.positionCaret(text.length());
+    }
+
+}

--- a/src/main/java/seedu/address/commons/util/UiUtil.java
+++ b/src/main/java/seedu/address/commons/util/UiUtil.java
@@ -1,11 +1,12 @@
 package seedu.address.commons.util;
 
+import java.util.function.Consumer;
+
 import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 
-import java.util.function.Consumer;
 
 /**
  * This class contains JavaFX-specific tasks

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -3,10 +3,16 @@ package seedu.address.ui;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
 import javafx.scene.layout.Region;
+import seedu.address.commons.util.UiUtil;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+
+import java.util.Stack;
+
+import static seedu.address.commons.util.UiUtil.setShortcut;
 
 /**
  * The UI component that is responsible for receiving user command inputs.
@@ -17,6 +23,8 @@ public class CommandBox extends UiPart<Region> {
     private static final String FXML = "CommandBox.fxml";
 
     private final CommandExecutor commandExecutor;
+    private Stack<String> undoStack;
+    private Stack<String> redoStack;
 
     @FXML
     private TextField commandTextField;
@@ -27,8 +35,19 @@ public class CommandBox extends UiPart<Region> {
     public CommandBox(CommandExecutor commandExecutor) {
         super(FXML);
         this.commandExecutor = commandExecutor;
+
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+
+        undoStack = new Stack<>();
+        redoStack = new Stack<>();
+
+        setShortcut(getRoot(), KeyCode.UP, (keyCode) -> {
+            undo();
+        });
+        setShortcut(getRoot(), KeyCode.DOWN, (keyCode) -> {
+            redo();
+        });
     }
 
     /**
@@ -43,6 +62,10 @@ public class CommandBox extends UiPart<Region> {
 
         try {
             commandExecutor.execute(commandText);
+
+            undoStack.push(commandText);
+            redoStack.clear();
+
             commandTextField.setText("");
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
@@ -82,4 +105,32 @@ public class CommandBox extends UiPart<Region> {
         CommandResult execute(String commandText) throws CommandException, ParseException;
     }
 
+    private void undo() {
+        if (!undoStack.isEmpty()) {
+            String text = undoStack.pop();
+
+            String currentText = commandTextField.getText();
+            redoStack.push(currentText);
+
+            UiUtil.setText(commandTextField, text);
+        }
+    }
+
+    private void redo() {
+        if (!redoStack.isEmpty()) {
+            String text = redoStack.pop();
+
+            String currentText = commandTextField.getText();
+            undoStack.push(currentText);
+
+            UiUtil.setText(commandTextField, text);
+        } else {
+            // This code block allows users to continue redoing until thye can an empty string, while still being able
+            // to undo from there
+            String currentText = commandTextField.getText();
+            undoStack.push(currentText);
+
+            commandTextField.setText(""); // Set as empty if there is nothing to redo
+        }
+    }
 }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,5 +1,9 @@
 package seedu.address.ui;
 
+import static seedu.address.commons.util.UiUtil.setShortcut;
+
+import java.util.Stack;
+
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
@@ -10,10 +14,6 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 
-import java.util.Stack;
-
-import static seedu.address.commons.util.UiUtil.setShortcut;
-
 /**
  * The UI component that is responsible for receiving user command inputs.
  */
@@ -23,8 +23,8 @@ public class CommandBox extends UiPart<Region> {
     private static final String FXML = "CommandBox.fxml";
 
     private final CommandExecutor commandExecutor;
-    private Stack<String> undoStack;
-    private Stack<String> redoStack;
+    private final Stack<String> undoStack;
+    private final Stack<String> redoStack;
 
     @FXML
     private TextField commandTextField;

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -129,7 +129,7 @@ public class CommandBox extends UiPart<Region> {
 
             UiUtil.setText(commandTextField, text);
         } else {
-            // This code block allows users to continue redoing until thye can an empty string, while still being able
+            // This code block allows users to continue redoing until there is an empty string, while still being able
             // to undo from there
             String currentText = commandTextField.getText();
             undoStack.push(currentText);

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -115,7 +115,7 @@ public class CommandBox extends UiPart<Region> {
 
             UiUtil.setText(commandTextField, text);
         } else {
-            // Plays a sound when there is nothing left to und
+            // Plays a sound when there is nothing left to undo
             AudioUtil.playAudio("assets/boop.mp3");
         }
     }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -9,6 +9,7 @@ import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.Region;
+import seedu.address.commons.util.AudioUtil;
 import seedu.address.commons.util.UiUtil;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -113,6 +114,9 @@ public class CommandBox extends UiPart<Region> {
             redoStack.push(currentText);
 
             UiUtil.setText(commandTextField, text);
+        } else {
+            // Plays a sound when there is nothing left to und
+            AudioUtil.playAudio("assets/boop.mp3");
         }
     }
 


### PR DESCRIPTION
Fixes #37

This PR enables the functionality of traversing through the user's history of commands using up (undo) and down (redo). This functionality aims to exactly match how it is like on macbook shells
1. Undo: Goes all the back until there is no more to undo
2. Redo: Goes all the way to the front until it reaches the end of the history, by then it will just set the command box to an empty string

Some points
1. Whatever you have in the current history, when you undo/redo, it will save that current text into the command history.