### PR TITLE
Fix patient data validation

### DIFF
--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -89,4 +89,17 @@ public class StringUtil {
             return false;
         }
     }
+
+    /**
+     * Trims whitesapce on both inside and outside the string. E.g. "  Tom     Dick " -> "Tom Dick"
+     * @param input Input to trim
+     * @return Trimmed input
+     */
+    public static String trimWhitespace(String input) {
+        // Remove leading and trailing whitespace
+        input = input.trim();
+        // Replace multiple whitespaces with a single space
+        input = input.replaceAll("\\s+", " ");
+        return input;
+    }
 }

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -96,6 +96,7 @@ public class StringUtil {
      * @return Trimmed input
      */
     public static String trimWhitespace(String input) {
+        requireNonNull(input);
         // Remove leading and trailing whitespace
         input = input.trim();
         // Replace multiple whitespaces with a single space

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -89,6 +89,9 @@ public class ParserUtil {
     public static Email parseEmail(String email) throws ParseException {
         requireNonNull(email);
         String trimmedEmail = email.trim();
+        // Store all emails in lowercase by default. Do not allow capitalisations
+        trimmedEmail = trimmedEmail.toLowerCase();
+
         if (!Email.isValidEmail(trimmedEmail)) {
             throw new ParseException(Email.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -43,7 +43,7 @@ public class ParserUtil {
      */
     public static Name parseName(String name) throws ParseException {
         requireNonNull(name);
-        String trimmedName = name.trim();
+        String trimmedName = StringUtil.trimWhitespace(name);
         if (!Name.isValidName(trimmedName)) {
             throw new ParseException(Name.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -56,7 +56,7 @@ public class Name {
         }
 
         Name otherName = (Name) other;
-        return fullName.equals(otherName.fullName);
+        return fullName.toLowerCase().equals(otherName.fullName.toLowerCase());
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -17,7 +17,7 @@ public class Phone {
     /**
      * Phone number regex matches the following conditions:
      * 1. Has exactly 3 OR 8 digits exactly
-     * 2. Starts with 6, 8 or 9. We ignore numbers starting with 3 since they're not nubmers that patients would have
+     * 2. Starts with 6, 8 or 9. We ignore numbers starting with 3 since they're not numbers that patients would have
      */
     public static final String VALIDATION_REGEX = "\\b[689]\\d{2}(\\d{5})?\\b";
     public final String value;

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -11,8 +11,15 @@ public class Phone {
 
 
     public static final String MESSAGE_CONSTRAINTS =
-            "Phone numbers should only contain numbers, and it should be at least 3 digits long";
-    public static final String VALIDATION_REGEX = "\\d{3,}";
+            "Phone numbers should only contain numbers, and it should be at least 3 or 8 digits long "
+                    + "and start with 6, 8 or 9";
+
+    /**
+     * Phone number regex matches the following conditions:
+     * 1. Has exactly 3 OR 8 digits exactly
+     * 2. Starts with 6, 8 or 9. We ignore numbers starting with 3 since they're not nubmers that patients would have
+     */
+    public static final String VALIDATION_REGEX = "\\b[689]\\d{2}(\\d{5})?\\b";
     public final String value;
 
     /**

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -18,6 +18,9 @@ public class Phone {
      * Phone number regex matches the following conditions:
      * 1. Has exactly 3 OR 8 digits exactly
      * 2. Starts with 6, 8 or 9. We ignore numbers starting with 3 since they're not numbers that patients would have
+     *
+     * Note that we currently do not validate against ALL invalid numbers like 666 or 88888888 due to technical
+     * complexities
      */
     public static final String VALIDATION_REGEX = "\\b[689]\\d{2}(\\d{5})?\\b";
     public final String value;

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
+    public static final String MESSAGE_CONSTRAINTS = "Tag names should be alphanumeric and should not be blank";
     public static final String VALIDATION_REGEX = "\\p{Alnum}+";
 
     public final String tagName;

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -29,7 +29,6 @@
       </HBox>
       <FlowPane fx:id="tags" />
       <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
     </VBox>
   </GridPane>

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -26,19 +26,19 @@
     "sid": 4
   }, {
     "name" : "Elle Meyer",
-    "phone" : "9482224",
+    "phone" : "94822240",
     "email" : "werner@example.com",
     "tags" : [ ],
     "sid": 5
   }, {
     "name" : "Fiona Kunz",
-    "phone" : "9482427",
+    "phone" : "94824270",
     "email" : "lydia@example.com",
     "tags" : [ ],
     "sid": 6
   }, {
     "name" : "George Best",
-    "phone" : "9482442",
+    "phone" : "94824420",
     "email" : "anna@example.com",
     "tags" : [ ],
     "sid": 7

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -28,8 +28,8 @@ public class CommandTestUtil {
 
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
-    public static final String VALID_PHONE_AMY = "11111111";
-    public static final String VALID_PHONE_BOB = "22222222";
+    public static final String VALID_PHONE_AMY = "61111111";
+    public static final String VALID_PHONE_BOB = "82222222";
     public static final String VALID_EMAIL_AMY = "amy@example.com";
     public static final String VALID_EMAIL_BOB = "bob@example.com";
     public static final String VALID_ADDRESS_AMY = "Block 312, Amy Street 1";

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -28,7 +28,7 @@ public class ParserUtilTest {
     private static final String INVALID_TAG = "#friend";
 
     private static final String VALID_NAME = "Rachel Walker";
-    private static final String VALID_PHONE = "123456";
+    private static final String VALID_PHONE = "92345612";
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -57,6 +57,12 @@ public class ParserUtilTest {
     }
 
     @Test
+    public void parseName_validWithInnerWhitespace_returnsTrimmedName() throws Exception {
+        String nameWithWhitespace = "  Bob   Choo  ";
+        Name expectedName = new Name("Bob Choo");
+        assertEquals(expectedName, ParserUtil.parseName(nameWithWhitespace));
+    }
+    @Test
     public void parseName_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseName((String) null));
     }
@@ -125,6 +131,11 @@ public class ParserUtilTest {
         assertEquals(expectedAddress, ParserUtil.parseAddress(addressWithWhitespace));
     }
 
+    @Test
+    public void parseEmail_validValue_returnsLowerCaseMeail() throws Exception {
+        Email expectedEmail = new Email("test@gmail.com");
+        assertEquals(expectedEmail, ParserUtil.parseEmail(expectedEmail.value.toUpperCase()));
+    }
     @Test
     public void parseEmail_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseEmail((String) null));

--- a/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/NameContainsKeywordsPredicateTest.java
@@ -70,7 +70,7 @@ public class NameContainsKeywordsPredicateTest {
 
         // Keywords match phone, email and address, but does not match name
         predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
-        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("999")
                 .withEmail("alice@email.com").withId(12).build()));
     }
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -40,14 +40,18 @@ public class PersonTest {
         editedAlice = new PersonBuilder(ALICE).withName(VALID_NAME_BOB).build();
         assertFalse(ALICE.isSamePerson(editedAlice));
 
-        // name differs in case, all other attributes same -> returns false
+        // name differs in case, all other attributes same -> returns true
         Person editedBob = new PersonBuilder(BOB).withName(VALID_NAME_BOB.toLowerCase()).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
 
-        // name has trailing spaces, all other attributes same -> returns false
+        // Name has extra white space in between words, all other attributes same -> returns true
+        editedBob = new PersonBuilder(BOB).withName("Bob  Choo").build();
+
+        assertTrue(BOB.isSamePerson(editedBob));
+        // name has trailing spaces, all other attributes same -> returns true
         String nameWithTrailingSpaces = VALID_NAME_BOB + " ";
         editedBob = new PersonBuilder(BOB).withName(nameWithTrailingSpaces).build();
-        assertFalse(BOB.isSamePerson(editedBob));
+        assertTrue(BOB.isSamePerson(editedBob));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -31,11 +31,14 @@ public class PhoneTest {
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
+        assertFalse(Phone.isValidPhone("9234")); // More than 3 numbers
+        assertFalse(Phone.isValidPhone("599")); // Doesn't start with 6, 8 or 9
 
         // valid phone numbers
         assertTrue(Phone.isValidPhone("911")); // exactly 3 numbers
-        assertTrue(Phone.isValidPhone("93121534"));
-        assertTrue(Phone.isValidPhone("124293842033123")); // long phone numbers
+        assertTrue(Phone.isValidPhone("63121534")); // Starts with 6, 8-digits
+        assertTrue(Phone.isValidPhone("83121534")); // Starts with 8, 8-digits
+        assertTrue(Phone.isValidPhone("93121534")); // Starts with 9, 8-digits
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -3,6 +3,7 @@ package seedu.address.testutil;
 import java.util.HashSet;
 import java.util.Set;
 
+import seedu.address.commons.util.StringUtil;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
@@ -51,7 +52,8 @@ public class PersonBuilder {
      * Sets the {@code Name} of the {@code Person} that we are building.
      */
     public PersonBuilder withName(String name) {
-        this.name = new Name(name);
+        String trimmedName = StringUtil.trimWhitespace(name);
+        this.name = new Name(trimmedName);
         return this;
     }
 

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -34,17 +34,17 @@ public class TypicalPersons {
             .withEmail("heinz@example.com").withId(3).build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withEmail("cornelia@example.com").withId(4).withTags("friends").build();
-    public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
+    public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("94822240")
             .withEmail("werner@example.com").withId(5).build();
-    public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
+    public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("94824270")
             .withEmail("lydia@example.com").withId(6).build();
-    public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
+    public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("94824420")
             .withEmail("anna@example.com").withId(7).build();
 
     // Manually added
-    public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("8482424")
+    public static final Person HOON = new PersonBuilder().withName("Hoon Meier").withPhone("84824240")
             .withEmail("stefan@example.com").withId(8).build();
-    public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
+    public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("84821310")
             .withEmail("hans@example.com").withId(9).build();
 
     // Manually added - Person's details found in {@code CommandTestUtil}


### PR DESCRIPTION
Fixes #38 

This PR aims to add additional input validation for patient fields
1. Name
   1. Whitespace between words are now trimmed to use only a single space
   2. Duplicate name validation is now case-insensitive. E.g. "NAM" and "Nam" are the same name
3. Phone numbers - Now have the following validation constraints
   1. Starts with 6, 8 or 9 only. We ignore 3 since those are not numbers that individuals would have
   2. Are either 3 or 8 characters long. No in-between lengths
4. Email - Emails are all lowercased upon saving

Some misc. changes
1. Fix typo "tags names" to "tag names"
2. Removed address UI from PersonListViewCell