### PR TITLE
Query appointments

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -3,6 +3,7 @@ package seedu.address.logic;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -48,7 +49,10 @@ public class LogicManager implements Logic {
         logger.info("----------------[USER COMMAND][" + commandText + "]");
 
         CommandResult commandResult;
-        Command command = addressBookParser.parseCommand(commandText);
+
+        List<Person> filteredPatients = this.getFilteredPersonList();
+
+        Command command = addressBookParser.parseCommand(commandText, filteredPatients);
         commandResult = command.execute(model);
 
         try {

--- a/src/main/java/seedu/address/logic/commands/ListAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAppointmentCommand.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PATIENT_ID;
 
 import java.util.function.Predicate;
 

--- a/src/main/java/seedu/address/logic/commands/ListAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAppointmentCommand.java
@@ -1,0 +1,45 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.Model;
+import seedu.address.model.appointment.Appointment;
+
+import java.util.function.Predicate;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.*;
+
+/**
+ * Lists all persons in the address book to the user.
+ */
+public class ListAppointmentCommand extends Command {
+
+    public static final String COMMAND_WORD = "queryappointments";
+
+    public static final String MESSAGE_SUCCESS = "Listed all appointments";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all appointments that meet the condition. "
+            + "Optional Parameters: "
+            + PREFIX_STUDENT_ID + "PATIENT_ID "
+            + PREFIX_NAME + "PATIENT_NAME "
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_STUDENT_ID + "1"
+            + "Or: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "John Doe" + " "
+            + "Note that you can only use one of the optional parameters at a time.";
+
+    private final Predicate<Appointment> predicates;
+
+    public ListAppointmentCommand(Predicate<Appointment> predicates) {
+        this.predicates = predicates;
+    }
+
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        model.updateFilteredAppointmentList(predicates);
+
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ListAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListAppointmentCommand.java
@@ -1,12 +1,12 @@
 package seedu.address.logic.commands;
 
-import seedu.address.model.Model;
-import seedu.address.model.appointment.Appointment;
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.*;
 
 import java.util.function.Predicate;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.*;
+import seedu.address.model.Model;
+import seedu.address.model.appointment.Appointment;
 
 /**
  * Lists all persons in the address book to the user.
@@ -19,10 +19,13 @@ public class ListAppointmentCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Lists all appointments that meet the condition. "
             + "Optional Parameters: "
-            + PREFIX_STUDENT_ID + "PATIENT_ID "
+            + PREFIX_APPOINTMENT_ID + "APPOINTMENT_ID "
+            + PREFIX_PATIENT_ID + "PATIENT_ID "
             + PREFIX_NAME + "PATIENT_NAME "
             + "Example: " + COMMAND_WORD + " "
-            + PREFIX_STUDENT_ID + "1"
+            + PREFIX_APPOINTMENT_ID + "1"
+            + "Or: " + COMMAND_WORD + " "
+            + PREFIX_PATIENT_ID + "1"
             + "Or: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe" + " "
             + "Note that you can only use one of the optional parameters at a time.";

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -19,6 +19,7 @@ import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindAppointmentCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListAppointmentCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -88,6 +89,9 @@ public class AddressBookParser {
 
         case DeleteAppointmentCommand.COMMAND_WORD:
             return new DeleteAppointmentCommandParser().parse(arguments);
+
+        case ListAppointmentCommand.COMMAND_WORD:
+            return new ListAppointmentCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -3,6 +3,7 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 
+import java.util.List;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -22,6 +23,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListAppointmentCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Person;
 
 /**
  * Parses user input.
@@ -37,11 +39,12 @@ public class AddressBookParser {
     /**
      * Parses user input into command for execution.
      *
-     * @param userInput full user input string
+     * @param userInput full user input string.
+     * @param patients list of patients.
      * @return the command based on the user input
      * @throws ParseException if the user input does not conform the expected format
      */
-    public Command parseCommand(String userInput) throws ParseException {
+    public Command parseCommand(String userInput, List<Person> patients) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
@@ -91,7 +94,7 @@ public class AddressBookParser {
             return new DeleteAppointmentCommandParser().parse(arguments);
 
         case ListAppointmentCommand.COMMAND_WORD:
-            return new ListAppointmentCommandParser().parse(arguments);
+            return new ListAppointmentCommandParser().parse(arguments, patients);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/ListAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListAppointmentCommandParser.java
@@ -12,14 +12,16 @@ import seedu.address.logic.commands.ListAppointmentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.appointment.Appointment;
 import seedu.address.model.appointment.AppointmentContainsPatientIdPredicate;
+import seedu.address.model.appointment.AppointmentContainsPatientNamePredicate;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
 
 /**
  * Parses input arguments and creates a new ListCommand object
  */
 public class ListAppointmentCommandParser implements Parser<ListAppointmentCommand> {
     @Override
-    public ListAppointmentCommand parse(String args) throws ParseException {
+    public ListAppointmentCommand parse(String args, List<Person> patients) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_STUDENT_ID);
 
@@ -38,8 +40,11 @@ public class ListAppointmentCommandParser implements Parser<ListAppointmentComma
 
         // All these criterias are OR not AND
         if (argMultimap.getValue(CliSyntax.PREFIX_NAME).isPresent()) {
-//            Name name = ParserUtil.parseName(argMultimap.getValue(CliSyntax.PREFIX_NAME).get());
-//            predicates.add(new AppointmentContainsPatientIdPredicate(Collections.singletonList(name.fullName)));
+            Name name = ParserUtil.parseName(argMultimap.getValue(CliSyntax.PREFIX_NAME).get());
+            predicates.add(new AppointmentContainsPatientNamePredicate(
+                    Collections.singletonList(name.fullName),
+                    patients
+            ));
             //TODO: Implement query appointment by name
             System.out.println("Hello boss");
         }
@@ -55,6 +60,11 @@ public class ListAppointmentCommandParser implements Parser<ListAppointmentComma
                 .reduce(p -> true, Predicate::and);
 
         return new ListAppointmentCommand(combinedPredicate);
+    }
+
+    @Override
+    public ListAppointmentCommand parse(String userInput) throws ParseException {
+        return null;
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ListAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListAppointmentCommandParser.java
@@ -1,0 +1,60 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT_ID;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_APPOINTMENTS;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.logic.commands.ListAppointmentCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.AppointmentContainsPatientIdPredicate;
+import seedu.address.model.person.Name;
+
+/**
+ * Parses input arguments and creates a new ListCommand object
+ */
+public class ListAppointmentCommandParser implements Parser<ListAppointmentCommand> {
+    @Override
+    public ListAppointmentCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_STUDENT_ID);
+
+        List<Predicate<Appointment>> predicates = new ArrayList<>();
+
+        // Checks if there is at least one prefix available.
+        boolean hasAtLeastOnePrefixPresent = ParserUtil.hasAtLeastOnePrefixPresent(argMultimap, CliSyntax.PREFIX_NAME,
+                CliSyntax.PREFIX_STUDENT_ID);
+
+        if (!hasAtLeastOnePrefixPresent || !argMultimap.getPreamble().isEmpty()) {
+            // If there is no prefix specified, then display all records.
+            // TODO: Show an error message here.
+            return new ListAppointmentCommand(PREDICATE_SHOW_ALL_APPOINTMENTS);
+        }
+
+
+        // All these criterias are OR not AND
+        if (argMultimap.getValue(CliSyntax.PREFIX_NAME).isPresent()) {
+//            Name name = ParserUtil.parseName(argMultimap.getValue(CliSyntax.PREFIX_NAME).get());
+//            predicates.add(new AppointmentContainsPatientIdPredicate(Collections.singletonList(name.fullName)));
+            //TODO: Implement query appointment by name
+            System.out.println("Hello boss");
+        }
+
+        if (argMultimap.getValue(CliSyntax.PREFIX_STUDENT_ID).isPresent()) {
+            int studentId = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_STUDENT_ID).get()).getOneBased();
+            predicates.add(
+                    new AppointmentContainsPatientIdPredicate(Collections.singletonList(String.valueOf(studentId)))
+            );
+        }
+        // Combine predicates with AND logic
+        Predicate<Appointment> combinedPredicate = predicates.stream()
+                .reduce(p -> true, Predicate::and);
+
+        return new ListAppointmentCommand(combinedPredicate);
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/ListAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListAppointmentCommandParser.java
@@ -54,7 +54,8 @@ public class ListAppointmentCommandParser implements Parser<ListAppointmentComma
         }
 
         if (argMultimap.getValue(CliSyntax.PREFIX_PATIENT_ID).isPresent()) {
-            int studentId = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_PATIENT_ID).get()).getOneBased();
+            int studentId = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_PATIENT_ID)
+                                                          .get()).getOneBased();
             predicates.add(
                     new AppointmentContainsPatientIdPredicate(Collections.singletonList(String.valueOf(studentId)))
             );

--- a/src/main/java/seedu/address/logic/parser/ListAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListAppointmentCommandParser.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STUDENT_ID;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_APPOINTMENTS;
 
 import java.util.ArrayList;
@@ -11,6 +10,7 @@ import java.util.function.Predicate;
 import seedu.address.logic.commands.ListAppointmentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.appointment.Appointment;
+import seedu.address.model.appointment.AppointmentContainsAppointmentIdPredicate;
 import seedu.address.model.appointment.AppointmentContainsPatientIdPredicate;
 import seedu.address.model.appointment.AppointmentContainsPatientNamePredicate;
 import seedu.address.model.person.Name;
@@ -23,13 +23,19 @@ public class ListAppointmentCommandParser implements Parser<ListAppointmentComma
     @Override
     public ListAppointmentCommand parse(String args, List<Person> patients) throws ParseException {
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, CliSyntax.PREFIX_NAME, CliSyntax.PREFIX_STUDENT_ID);
+                ArgumentTokenizer.tokenize(args,
+                                           CliSyntax.PREFIX_NAME,
+                                           CliSyntax.PREFIX_PATIENT_ID,
+                                           CliSyntax.PREFIX_APPOINTMENT_ID);
 
         List<Predicate<Appointment>> predicates = new ArrayList<>();
 
         // Checks if there is at least one prefix available.
-        boolean hasAtLeastOnePrefixPresent = ParserUtil.hasAtLeastOnePrefixPresent(argMultimap, CliSyntax.PREFIX_NAME,
-                CliSyntax.PREFIX_STUDENT_ID);
+        boolean hasAtLeastOnePrefixPresent = ParserUtil.hasAtLeastOnePrefixPresent(
+                argMultimap,
+                CliSyntax.PREFIX_NAME,
+                CliSyntax.PREFIX_PATIENT_ID,
+                CliSyntax.PREFIX_APPOINTMENT_ID);
 
         if (!hasAtLeastOnePrefixPresent || !argMultimap.getPreamble().isEmpty()) {
             // If there is no prefix specified, then display all records.
@@ -45,14 +51,22 @@ public class ListAppointmentCommandParser implements Parser<ListAppointmentComma
                     Collections.singletonList(name.fullName),
                     patients
             ));
-            //TODO: Implement query appointment by name
-            System.out.println("Hello boss");
         }
 
-        if (argMultimap.getValue(CliSyntax.PREFIX_STUDENT_ID).isPresent()) {
-            int studentId = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_STUDENT_ID).get()).getOneBased();
+        if (argMultimap.getValue(CliSyntax.PREFIX_PATIENT_ID).isPresent()) {
+            int studentId = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_PATIENT_ID).get()).getOneBased();
             predicates.add(
                     new AppointmentContainsPatientIdPredicate(Collections.singletonList(String.valueOf(studentId)))
+            );
+        }
+
+        if (argMultimap.getValue(CliSyntax.PREFIX_APPOINTMENT_ID).isPresent()) {
+            int appointmentId = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_APPOINTMENT_ID)
+                                                          .get()).getOneBased();
+            predicates.add(
+                    new AppointmentContainsAppointmentIdPredicate(
+                            Collections.singletonList(String.valueOf(appointmentId))
+                    )
             );
         }
         // Combine predicates with AND logic

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -1,12 +1,10 @@
 package seedu.address.logic.parser;
 
+import java.util.List;
+
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Person;
-
-import java.util.List;
-
-
 /**
  * Represents a Parser that is able to parse user input into a {@code Command} of type {@code T}.
  */

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -2,6 +2,10 @@ package seedu.address.logic.parser;
 
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Person;
+
+import java.util.List;
+
 
 /**
  * Represents a Parser that is able to parse user input into a {@code Command} of type {@code T}.
@@ -13,4 +17,14 @@ public interface Parser<T extends Command> {
      * @throws ParseException if {@code userInput} does not conform the expected format
      */
     T parse(String userInput) throws ParseException;
+
+    /**
+     * Parses {@code userInput} into a command and returns it. Takes in a list of people to help with querying and
+     * parsing validation, such as "no such person exists" errors.
+     * Declared as a default method to avoid overwriting methods for other unrelated classes
+     * @throws ParseException if {@code userInput} does not conform the expected format
+     */
+    default T parse(String userInput, List<Person> patients) throws ParseException {
+        throw new UnsupportedOperationException("This method is not implemented.");
+    }
 }

--- a/src/main/java/seedu/address/model/appointment/AppointmentContainsAppointmentIdPredicate.java
+++ b/src/main/java/seedu/address/model/appointment/AppointmentContainsAppointmentIdPredicate.java
@@ -1,0 +1,46 @@
+package seedu.address.model.appointment;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Appointment}'s id matches any of the keywords given.
+ */
+public class AppointmentContainsAppointmentIdPredicate implements Predicate<Appointment> {
+    private final List<String> keywords;
+
+    public AppointmentContainsAppointmentIdPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Appointment appointment) {
+        // We check for equality here instead of containsIn because otherwise, student 1 would match with 100
+        return keywords.stream()
+                .anyMatch(keyword -> String.valueOf(appointment.getAppointmentId()).equals(keyword)
+                );
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AppointmentContainsAppointmentIdPredicate)) {
+            return false;
+        }
+
+        AppointmentContainsAppointmentIdPredicate otherNameContainsKeywordsPredicate =
+                (AppointmentContainsAppointmentIdPredicate) other;
+        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/appointment/AppointmentContainsAppointmentIdPredicate.java
+++ b/src/main/java/seedu/address/model/appointment/AppointmentContainsAppointmentIdPredicate.java
@@ -1,9 +1,10 @@
 package seedu.address.model.appointment;
 
-import seedu.address.commons.util.ToStringBuilder;
-
 import java.util.List;
 import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+
 
 /**
  * Tests that a {@code Appointment}'s id matches any of the keywords given.

--- a/src/main/java/seedu/address/model/appointment/AppointmentContainsPatientIdPredicate.java
+++ b/src/main/java/seedu/address/model/appointment/AppointmentContainsPatientIdPredicate.java
@@ -1,0 +1,47 @@
+package seedu.address.model.appointment;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ */
+public class AppointmentContainsPatientIdPredicate implements Predicate<Appointment> {
+    private final List<String> keywords;
+
+    public AppointmentContainsPatientIdPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Appointment appointment) {
+        // We check for equality here instead of containsIn because otherwise, student 1 would match with 100
+        System.out.println("Bogwash " + appointment + " " + keywords);
+        return keywords.stream()
+                .anyMatch(keyword -> String.valueOf(appointment.getStudentId()).equals(keyword)
+                );
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AppointmentContainsPatientIdPredicate)) {
+            return false;
+        }
+
+        AppointmentContainsPatientIdPredicate otherNameContainsKeywordsPredicate =
+                (AppointmentContainsPatientIdPredicate) other;
+        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/appointment/AppointmentContainsPatientIdPredicate.java
+++ b/src/main/java/seedu/address/model/appointment/AppointmentContainsPatientIdPredicate.java
@@ -6,7 +6,7 @@ import java.util.function.Predicate;
 import seedu.address.commons.util.ToStringBuilder;
 
 /**
- * Tests that a {@code Person}'s {@code Name} matches any of the keywords given.
+ * Tests that a {@code Appointment}'s patientId matches any of the keywords given.
  */
 public class AppointmentContainsPatientIdPredicate implements Predicate<Appointment> {
     private final List<String> keywords;
@@ -18,7 +18,6 @@ public class AppointmentContainsPatientIdPredicate implements Predicate<Appointm
     @Override
     public boolean test(Appointment appointment) {
         // We check for equality here instead of containsIn because otherwise, student 1 would match with 100
-        System.out.println("Bogwash " + appointment + " " + keywords);
         return keywords.stream()
                 .anyMatch(keyword -> String.valueOf(appointment.getStudentId()).equals(keyword)
                 );

--- a/src/main/java/seedu/address/model/appointment/AppointmentContainsPatientNamePredicate.java
+++ b/src/main/java/seedu/address/model/appointment/AppointmentContainsPatientNamePredicate.java
@@ -1,0 +1,66 @@
+package seedu.address.model.appointment;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.person.Person;
+
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+/**
+ * Tests that a {@code Name} matches the {@code Person} that the appointment is associated with
+ */
+public class AppointmentContainsPatientNamePredicate implements Predicate<Appointment> {
+    private final List<String> keywords;
+    private final List<Person> patients;
+
+    /**
+     * Constructor for AppointmentContainsPatientNamePredicate
+     * @param keywords
+     * @param patients The current observable list of patients
+     */
+    public AppointmentContainsPatientNamePredicate(List<String> keywords, List<Person> patients) {
+        this.keywords = keywords;
+        this.patients = patients;
+    }
+
+    @Override
+    public boolean test(Appointment appointment) {
+        // 1. Map names to patient IDs
+        // 2. Check if the appointment's patient name matches any of the keywords
+        for (String keyword: keywords) {
+            List<Integer> patientIdsMatched = patients.stream()
+                    .filter(patient -> StringUtil.containsStringIgnoreCase(patient.getName().fullName, keyword))
+                    .map(patient -> patient.getSid())
+                    .collect(Collectors.toList());
+            for (int patientId: patientIdsMatched) {
+                if (appointment.getStudentId() == patientId) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AppointmentContainsPatientNamePredicate)) {
+            return false;
+        }
+
+        AppointmentContainsPatientNamePredicate otherNameContainsKeywordsPredicate =
+                (AppointmentContainsPatientNamePredicate) other;
+        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/appointment/AppointmentContainsPatientNamePredicate.java
+++ b/src/main/java/seedu/address/model/appointment/AppointmentContainsPatientNamePredicate.java
@@ -1,12 +1,13 @@
 package seedu.address.model.appointment;
 
+import java.util.List;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
 import seedu.address.commons.util.StringUtil;
 import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.person.Person;
 
-import java.util.List;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 /**
  * Tests that a {@code Name} matches the {@code Person} that the appointment is associated with

--- a/src/main/java/seedu/address/model/appointment/UniqueAppointmentList.java
+++ b/src/main/java/seedu/address/model/appointment/UniqueAppointmentList.java
@@ -8,8 +8,8 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.appointment.exceptions.AppointmentNotFoundException;
 import seedu.address.model.appointment.exceptions.DuplicateAppointmentException;
-import seedu.address.model.person.exceptions.PersonNotFoundException;
 
 /**
  * A list of appointments that enforces uniqueness between its elements and does not allow nulls.
@@ -60,7 +60,7 @@ public class UniqueAppointmentList implements Iterable<Appointment> {
 
         int index = internalList.indexOf(target);
         if (index == -1) {
-            throw new PersonNotFoundException();
+            throw new AppointmentNotFoundException();
         }
 
         if (!target.isSameAppointment(editedAppointment) && contains(editedAppointment)) {
@@ -77,7 +77,7 @@ public class UniqueAppointmentList implements Iterable<Appointment> {
     public void remove(Appointment toRemove) {
         requireNonNull(toRemove);
         if (!internalList.remove(toRemove)) {
-            throw new PersonNotFoundException();
+            throw new AppointmentNotFoundException();
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/ListAppointmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListAppointmentCommandTest.java
@@ -1,16 +1,19 @@
 package seedu.address.logic.commands;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import seedu.address.model.Model;
-import seedu.address.model.ModelManager;
-import seedu.address.model.UserPrefs;
-
-import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showAppointmentAtIndex;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_APPOINTMENTS;
 import static seedu.address.testutil.TypicalAppointments.getTypicalAppointmentList;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_APPOINTMENT;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for ListAppointmentCommand.

--- a/src/test/java/seedu/address/logic/commands/ListAppointmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListAppointmentCommandTest.java
@@ -1,0 +1,42 @@
+package seedu.address.logic.commands;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_APPOINTMENTS;
+import static seedu.address.testutil.TypicalAppointments.getTypicalAppointmentList;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_APPOINTMENT;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListAppointmentCommand.
+ */
+public class ListAppointmentCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), getTypicalAppointmentList(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), model.getAppointmentList(), new UserPrefs());
+        System.out.println(1);
+    }
+
+    @Test
+    public void execute_listIsNotFiltered_showsSameList() {
+        assertCommandSuccess(new ListAppointmentCommand(PREDICATE_SHOW_ALL_APPOINTMENTS),
+                model, ListAppointmentCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsFiltered_showsEverything() {
+        showAppointmentAtIndex(model, INDEX_FIRST_APPOINTMENT);
+        assertCommandSuccess(new ListAppointmentCommand(PREDICATE_SHOW_ALL_APPOINTMENTS),
+                model, ListAppointmentCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -6,11 +6,14 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddCommand;
@@ -23,6 +26,9 @@ import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -33,69 +39,89 @@ public class AddressBookParserTest {
 
     private final AddressBookParser parser = new AddressBookParser();
 
+    private Model model;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    }
+
     @Test
     public void parseCommand_add() throws Exception {
+        List<Person> patients = model.getFilteredPersonList();
         Person person = new PersonBuilder().build();
-        AddCommand command = (AddCommand) parser.parseCommand(PersonUtil.getAddCommand(person));
+        AddCommand command = (AddCommand) parser.parseCommand(PersonUtil.getAddCommand(person), patients);
         assertEquals(new AddCommand(person), command);
     }
 
     @Test
     public void parseCommand_clear() throws Exception {
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
+        List<Person> patients = model.getFilteredPersonList();
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, patients) instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3", patients) instanceof ClearCommand);
     }
 
     @Test
     public void parseCommand_delete() throws Exception {
+        List<Person> patients = model.getFilteredPersonList();
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased(), patients);
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
     }
 
     @Test
     public void parseCommand_edit() throws Exception {
+        List<Person> patients = model.getFilteredPersonList();
         Person person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
-                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+                + INDEX_FIRST_PERSON.getOneBased() + " "
+                + PersonUtil.getEditPersonDescriptorDetails(descriptor), patients);
         assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
     }
 
     @Test
     public void parseCommand_exit() throws Exception {
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
+        List<Person> patients = model.getFilteredPersonList();
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, patients) instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3", patients) instanceof ExitCommand);
     }
 
     @Test
     public void parseCommand_find() throws Exception {
+        List<Person> patients = model.getFilteredPersonList();
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")),
+                patients);
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 
     @Test
     public void parseCommand_help() throws Exception {
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
+        List<Person> patients = model.getFilteredPersonList();
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, patients) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3", patients) instanceof HelpCommand);
     }
 
     @Test
     public void parseCommand_list() throws Exception {
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+        List<Person> patients = model.getFilteredPersonList();
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, patients) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3", patients) instanceof ListCommand);
     }
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
+        List<Person> patients = model.getFilteredPersonList();
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand(""));
+            -> parser.parseCommand("", patients));
     }
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
-        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () -> parser.parseCommand("unknownCommand"));
+        List<Person> patients = model.getFilteredPersonList();
+        assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () ->
+                parser.parseCommand("unknownCommand", patients));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -9,7 +9,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 


### PR DESCRIPTION
Fixes #40 

### Describe your changes
Added a new command `queryappointments` that lists all appointments and takes in additional params
1. student Id so that we can query all appointments by student id
2. student name, so that we can query all appointments by student name
3. appointment id

**Notes**
1. I added a new function in the Parser interface that accepts a list of Patients. This is because I needed this list of existing patients in order to identify the student Ids by name
2. There is no ListCommandParserTest because there doesn't seem to be any pre-existing test for this right now. I also want to avoid writing more tests than necessary, at least for now

**This is to be merged AFTER #71**