### PR TITLE
Add appointment validation

### DIFF
--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -3,7 +3,6 @@ package seedu.address.logic;
 import java.io.IOException;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -41,7 +41,8 @@ public class LogicManager implements Logic {
     public LogicManager(Model model, Storage storage) {
         this.model = model;
         this.storage = storage;
-        addressBookParser = new AddressBookParser();
+        List<Person> filteredPatients = this.getFilteredPersonList();
+        addressBookParser = new AddressBookParser(filteredPatients);
     }
 
     @Override
@@ -50,9 +51,7 @@ public class LogicManager implements Logic {
 
         CommandResult commandResult;
 
-        List<Person> filteredPatients = this.getFilteredPersonList();
-
-        Command command = addressBookParser.parseCommand(commandText, filteredPatients);
+        Command command = addressBookParser.parseCommand(commandText);
         commandResult = command.execute(model);
 
         try {

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -41,8 +41,10 @@ public class LogicManager implements Logic {
     public LogicManager(Model model, Storage storage) {
         this.model = model;
         this.storage = storage;
-        List<Person> filteredPatients = this.getFilteredPersonList();
-        addressBookParser = new AddressBookParser(filteredPatients);
+        addressBookParser = new AddressBookParser(
+                this.model.getAddressBook().getPersonList(),
+                this.model.getAppointmentList().getAppointmentList()
+        );
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -23,6 +23,14 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_INVALID_PATIENT_ID = "No such patient with id %1$d exists";
+
+    public static final String MESSAGE_INVALID_DATE_TIME = "Invalid date time format. "
+            + "Please use the format yyyy-MM-dd HH:mm";
+
+    public static final String MESSAGE_INVALID_BOOLEAN_VALUE = "Invalid boolean value. Please use true or false.";
+    public static final String MESSAGE_DATETIME_IN_THE_PAST =
+            "Date and time cannot be in the past";
+
     /**
      * Returns an error message indicating the duplicate prefixes.
      */

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -22,7 +22,7 @@ public class Messages {
     public static final String MESSAGE_APPOINTMENTS_LISTED_OVERVIEW = "%1$d appointments listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
-
+    public static final String MESSAGE_INVALID_PATIENT_ID = "No such patient with id %1$d exists";
     /**
      * Returns an error message indicating the duplicate prefixes.
      */

--- a/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
@@ -10,7 +10,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PATIENT_ID;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import seedu.address.logic.Messages;
 import seedu.address.logic.commands.AddAppointmentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.appointment.Appointment;
@@ -22,8 +21,17 @@ import seedu.address.model.util.RelationshipUtil;
  */
 public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand> {
     private final List<Person> patients;
-    public AddAppointmentCommandParser(List<Person> patients) {
+    private final List<Appointment> appointments;
+
+    /**
+     * Takes in multiple lists so as to perform validation checks against them
+     *
+     * @param patients List of patients
+     * @param appointments List of appointments
+     */
+    public AddAppointmentCommandParser(List<Person> patients, List<Appointment> appointments) {
         this.patients = patients;
+        this.appointments = appointments;
     }
     /**
      * Parses the given {@code String} of arguments in the context of the AddAppointmentCommand
@@ -52,8 +60,8 @@ public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand
         }
 
         LocalDateTime appointmentDateTime = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATETIME).get());
-        if (appointmentDateTime.isBefore(LocalDateTime.now())) {
-            throw new ParseException(Messages.MESSAGE_DATETIME_IN_THE_PAST);
+        if (RelationshipUtil.isAppointmentDateTimeAlreadyTaken(appointmentDateTime, this.appointments)) {
+            throw new ParseException(Appointment.MESSAGE_DATETIME_ALREADY_TAKEN);
         }
         boolean hasAttended = ParserUtil.parseHasAttended(argMultimap.getValue(PREFIX_ATTEND).orElse(""));
         //TODO: remove after case log is implemented

--- a/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
@@ -10,6 +10,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PATIENT_ID;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.AddAppointmentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.appointment.Appointment;
@@ -48,6 +49,9 @@ public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand
         }
 
         LocalDateTime appointmentDateTime = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATETIME).get());
+        if (appointmentDateTime.isBefore(LocalDateTime.now())) {
+            throw new ParseException(Messages.MESSAGE_DATETIME_IN_THE_PAST);
+        }
         boolean hasAttended = ParserUtil.parseHasAttended(argMultimap.getValue(PREFIX_ATTEND).orElse(""));
         //TODO: remove after case log is implemented
         String appointmentDescription = ParserUtil.parseDescription(

--- a/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
@@ -21,13 +21,16 @@ import seedu.address.model.util.RelationshipUtil;
  * Parses input arguments and creates a new AddAppointmentCommand object
  */
 public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand> {
-
+    private final List<Person> patients;
+    public AddAppointmentCommandParser(List<Person> patients) {
+        this.patients = patients;
+    }
     /**
      * Parses the given {@code String} of arguments in the context of the AddAppointmentCommand
      * and returns an AddAppointmentCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public AddAppointmentCommand parse(String args, List<Person> patients) throws ParseException {
+    public AddAppointmentCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_PATIENT_ID, PREFIX_DATETIME,
                         PREFIX_ATTEND, PREFIX_APPOINTMENT_DESCRIPTION);
@@ -59,10 +62,5 @@ public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand
 
         Appointment appointment = new Appointment(appointmentDateTime, studentId, appointmentDescription, hasAttended);
         return new AddAppointmentCommand(appointment);
-    }
-
-    @Override
-    public AddAppointmentCommand parse(String userInput) throws ParseException {
-        return null;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAppointmentCommandParser.java
@@ -1,16 +1,20 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_PATIENT_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_APPOINTMENT_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ATTEND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATETIME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PATIENT_ID;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 import seedu.address.logic.commands.AddAppointmentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.appointment.Appointment;
+import seedu.address.model.person.Person;
+import seedu.address.model.util.RelationshipUtil;
 
 /**
  * Parses input arguments and creates a new AddAppointmentCommand object
@@ -22,7 +26,7 @@ public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand
      * and returns an AddAppointmentCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public AddAppointmentCommand parse(String args) throws ParseException {
+    public AddAppointmentCommand parse(String args, List<Person> patients) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_PATIENT_ID, PREFIX_DATETIME,
                         PREFIX_ATTEND, PREFIX_APPOINTMENT_DESCRIPTION);
@@ -36,6 +40,13 @@ public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand
         argMultimap.verifyNoDuplicatePrefixesFor(
                 PREFIX_PATIENT_ID, PREFIX_DATETIME, PREFIX_ATTEND, PREFIX_APPOINTMENT_DESCRIPTION);
         int studentId = ParserUtil.parseIndex(argMultimap.getValue(PREFIX_PATIENT_ID).get()).getOneBased();
+
+        if (!RelationshipUtil.personExists(studentId, patients)) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_PATIENT_ID, studentId)
+             );
+        }
+
         LocalDateTime appointmentDateTime = ParserUtil.parseDateTime(argMultimap.getValue(PREFIX_DATETIME).get());
         boolean hasAttended = ParserUtil.parseHasAttended(argMultimap.getValue(PREFIX_ATTEND).orElse(""));
         //TODO: remove after case log is implemented
@@ -46,4 +57,8 @@ public class AddAppointmentCommandParser implements Parser<AddAppointmentCommand
         return new AddAppointmentCommand(appointment);
     }
 
+    @Override
+    public AddAppointmentCommand parse(String userInput) throws ParseException {
+        return null;
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -36,15 +36,20 @@ public class AddressBookParser {
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
     private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
 
+    private final List<Person> patients;
+
+    public AddressBookParser(List<Person> patients) {
+        this.patients = patients;
+    }
+
     /**
      * Parses user input into command for execution.
      *
      * @param userInput full user input string.
-     * @param patients list of patients.
      * @return the command based on the user input
      * @throws ParseException if the user input does not conform the expected format
      */
-    public Command parseCommand(String userInput, List<Person> patients) throws ParseException {
+    public Command parseCommand(String userInput) throws ParseException {
         final Matcher matcher = BASIC_COMMAND_FORMAT.matcher(userInput.trim());
         if (!matcher.matches()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE));
@@ -85,7 +90,7 @@ public class AddressBookParser {
             return new HelpCommand();
 
         case AddAppointmentCommand.COMMAND_WORD:
-            return new AddAppointmentCommandParser().parse(arguments, patients);
+            return new AddAppointmentCommandParser().parse(arguments, this.patients);
 
         case FindAppointmentCommand.COMMAND_WORD:
             return new FindAppointmentCommandParser().parse(arguments);
@@ -94,7 +99,7 @@ public class AddressBookParser {
             return new DeleteAppointmentCommandParser().parse(arguments);
 
         case ListAppointmentCommand.COMMAND_WORD:
-            return new ListAppointmentCommandParser().parse(arguments, patients);
+            return new ListAppointmentCommandParser().parse(arguments, this.patients);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -90,7 +90,7 @@ public class AddressBookParser {
             return new HelpCommand();
 
         case AddAppointmentCommand.COMMAND_WORD:
-            return new AddAppointmentCommandParser().parse(arguments, this.patients);
+            return new AddAppointmentCommandParser(this.patients).parse(arguments);
 
         case FindAppointmentCommand.COMMAND_WORD:
             return new FindAppointmentCommandParser().parse(arguments);
@@ -99,7 +99,7 @@ public class AddressBookParser {
             return new DeleteAppointmentCommandParser().parse(arguments);
 
         case ListAppointmentCommand.COMMAND_WORD:
-            return new ListAppointmentCommandParser().parse(arguments, this.patients);
+            return new ListAppointmentCommandParser(this.patients).parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -85,7 +85,7 @@ public class AddressBookParser {
             return new HelpCommand();
 
         case AddAppointmentCommand.COMMAND_WORD:
-            return new AddAppointmentCommandParser().parse(arguments);
+            return new AddAppointmentCommandParser().parse(arguments, patients);
 
         case FindAppointmentCommand.COMMAND_WORD:
             return new FindAppointmentCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -23,6 +23,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListAppointmentCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.Person;
 
 /**
@@ -37,9 +38,11 @@ public class AddressBookParser {
     private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
 
     private final List<Person> patients;
+    private final List<Appointment> appointments;
 
-    public AddressBookParser(List<Person> patients) {
+    public AddressBookParser(List<Person> patients, List<Appointment> appointments) {
         this.patients = patients;
+        this.appointments = appointments;
     }
 
     /**
@@ -90,7 +93,7 @@ public class AddressBookParser {
             return new HelpCommand();
 
         case AddAppointmentCommand.COMMAND_WORD:
-            return new AddAppointmentCommandParser(this.patients).parse(arguments);
+            return new AddAppointmentCommandParser(this.patients, this.appointments).parse(arguments);
 
         case FindAppointmentCommand.COMMAND_WORD:
             return new FindAppointmentCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -40,6 +40,10 @@ public class AddressBookParser {
     private final List<Person> patients;
     private final List<Appointment> appointments;
 
+    /**
+     * @param patients List of patients
+     * @param appointments List of appointments
+     */
     public AddressBookParser(List<Person> patients, List<Appointment> appointments) {
         this.patients = patients;
         this.appointments = appointments;

--- a/src/main/java/seedu/address/logic/parser/ListAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListAppointmentCommandParser.java
@@ -22,8 +22,13 @@ import seedu.address.model.util.RelationshipUtil;
  * Parses input arguments and creates a new ListCommand object
  */
 public class ListAppointmentCommandParser implements Parser<ListAppointmentCommand> {
+
+    private final List<Person> patients;
+    public ListAppointmentCommandParser(List<Person> patients) {
+        this.patients = patients;
+    }
     @Override
-    public ListAppointmentCommand parse(String args, List<Person> patients) throws ParseException {
+    public ListAppointmentCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args,
                                            CliSyntax.PREFIX_NAME,
@@ -83,10 +88,4 @@ public class ListAppointmentCommandParser implements Parser<ListAppointmentComma
 
         return new ListAppointmentCommand(combinedPredicate);
     }
-
-    @Override
-    public ListAppointmentCommand parse(String userInput) throws ParseException {
-        return null;
-    }
-
 }

--- a/src/main/java/seedu/address/logic/parser/ListAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListAppointmentCommandParser.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.ListAppointmentCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.appointment.Appointment;
@@ -15,6 +16,7 @@ import seedu.address.model.appointment.AppointmentContainsPatientIdPredicate;
 import seedu.address.model.appointment.AppointmentContainsPatientNamePredicate;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
+import seedu.address.model.util.RelationshipUtil;
 
 /**
  * Parses input arguments and creates a new ListCommand object
@@ -56,6 +58,11 @@ public class ListAppointmentCommandParser implements Parser<ListAppointmentComma
         if (argMultimap.getValue(CliSyntax.PREFIX_PATIENT_ID).isPresent()) {
             int studentId = ParserUtil.parseIndex(argMultimap.getValue(CliSyntax.PREFIX_PATIENT_ID)
                                                           .get()).getOneBased();
+            if (!RelationshipUtil.personExists(studentId, patients)) {
+                throw new ParseException(
+                        String.format(Messages.MESSAGE_INVALID_PATIENT_ID, studentId)
+                );
+            }
             predicates.add(
                     new AppointmentContainsPatientIdPredicate(Collections.singletonList(String.valueOf(studentId)))
             );

--- a/src/main/java/seedu/address/logic/parser/Parser.java
+++ b/src/main/java/seedu/address/logic/parser/Parser.java
@@ -1,10 +1,7 @@
 package seedu.address.logic.parser;
 
-import java.util.List;
-
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Person;
 /**
  * Represents a Parser that is able to parse user input into a {@code Command} of type {@code T}.
  */
@@ -15,14 +12,4 @@ public interface Parser<T extends Command> {
      * @throws ParseException if {@code userInput} does not conform the expected format
      */
     T parse(String userInput) throws ParseException;
-
-    /**
-     * Parses {@code userInput} into a command and returns it. Takes in a list of people to help with querying and
-     * parsing validation, such as "no such person exists" errors.
-     * Declared as a default method to avoid overwriting methods for other unrelated classes
-     * @throws ParseException if {@code userInput} does not conform the expected format
-     */
-    default T parse(String userInput, List<Person> patients) throws ParseException {
-        throw new UnsupportedOperationException("This method is not implemented.");
-    }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -11,8 +11,8 @@ import java.util.stream.Stream;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.Messages;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
@@ -143,7 +143,7 @@ public class ParserUtil {
         try {
             localDateTime = LocalDateTime.parse(trimmedDateTime, format);
         } catch (Exception e) {
-            throw new ParseException(Appointment.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Messages.MESSAGE_INVALID_DATE_TIME);
         }
         return localDateTime;
     }
@@ -163,7 +163,7 @@ public class ParserUtil {
         String trimmedAttend = attend.trim();
         if (!trimmedAttend.equalsIgnoreCase("true")
                 && !trimmedAttend.equalsIgnoreCase("false")) {
-            throw new ParseException(Appointment.MESSAGE_CONSTRAINTS);
+            throw new ParseException(Messages.MESSAGE_INVALID_BOOLEAN_VALUE);
         }
         return Boolean.parseBoolean(trimmedAttend);
     }

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -12,9 +12,6 @@ import seedu.address.commons.util.ToStringBuilder;
  * TODO: check if need to enforcing immutable
  */
 public class Appointment implements Comparable<Appointment> {
-    //TODO: is there any specific constraints to check in appointment?
-    public static final String MESSAGE_CONSTRAINTS =
-            "Appointment constraints";
     private static final boolean DEFAULT_ATTENDED_STATUS = false;
 
     private static int idTracker = 1;

--- a/src/main/java/seedu/address/model/appointment/Appointment.java
+++ b/src/main/java/seedu/address/model/appointment/Appointment.java
@@ -12,6 +12,7 @@ import seedu.address.commons.util.ToStringBuilder;
  * TODO: check if need to enforcing immutable
  */
 public class Appointment implements Comparable<Appointment> {
+    public static final String MESSAGE_DATETIME_ALREADY_TAKEN = "There is already an appointment at that time";
     private static final boolean DEFAULT_ATTENDED_STATUS = false;
 
     private static int idTracker = 1;

--- a/src/main/java/seedu/address/model/util/RelationshipUtil.java
+++ b/src/main/java/seedu/address/model/util/RelationshipUtil.java
@@ -1,7 +1,9 @@
 package seedu.address.model.util;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
+import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.Person;
 
 
@@ -11,5 +13,14 @@ import seedu.address.model.person.Person;
 public class RelationshipUtil {
     public static boolean personExists(int id, List<Person> patients) {
         return patients.stream().anyMatch(patient -> patient.getSid() == id);
+    }
+
+    public static boolean isAppointmentDateTimeAlreadyTaken(LocalDateTime dateTime, List<Appointment> appointments) {
+        for (Appointment appointment: appointments) {
+            if (appointment.getAppointmentDateTime().equals(dateTime)) {
+                return true;
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/seedu/address/model/util/RelationshipUtil.java
+++ b/src/main/java/seedu/address/model/util/RelationshipUtil.java
@@ -11,10 +11,22 @@ import seedu.address.model.person.Person;
  * In charge of enforcing relationship constraints between models
  */
 public class RelationshipUtil {
+
+    /**
+     * Checks if a {@code Person} with the given ID exists
+     * @param id personId
+     * @param patients List of {@code Person}
+     * @return
+     */
     public static boolean personExists(int id, List<Person> patients) {
         return patients.stream().anyMatch(patient -> patient.getSid() == id);
     }
 
+    /**
+     * Checks if the given date and time is already usedby another {@code Appointment}.
+     * @param dateTime DAte time to check for
+     * @param appointments List of {@code Appointment}s to check against
+     */
     public static boolean isAppointmentDateTimeAlreadyTaken(LocalDateTime dateTime, List<Appointment> appointments) {
         for (Appointment appointment: appointments) {
             if (appointment.getAppointmentDateTime().equals(dateTime)) {

--- a/src/main/java/seedu/address/model/util/RelationshipUtil.java
+++ b/src/main/java/seedu/address/model/util/RelationshipUtil.java
@@ -1,0 +1,14 @@
+package seedu.address.model.util;
+
+import seedu.address.model.person.Person;
+
+import java.util.List;
+
+/**
+ * In charge of enforcing relationship constraints between models
+ */
+public class RelationshipUtil {
+    public static boolean personExists(int id, List<Person> patients) {
+        return patients.stream().anyMatch(patient -> patient.getSid() == id);
+    }
+}

--- a/src/main/java/seedu/address/model/util/RelationshipUtil.java
+++ b/src/main/java/seedu/address/model/util/RelationshipUtil.java
@@ -1,8 +1,9 @@
 package seedu.address.model.util;
 
+import java.util.List;
+
 import seedu.address.model.person.Person;
 
-import java.util.List;
 
 /**
  * In charge of enforcing relationship constraints between models

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -36,91 +36,82 @@ import seedu.address.testutil.PersonUtil;
 
 public class AddressBookParserTest {
 
-    private final AddressBookParser parser = new AddressBookParser();
+    private AddressBookParser parser;
 
     private Model model;
 
     @BeforeEach
     public void setUp() {
         model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        parser = new AddressBookParser(model.getFilteredPersonList());
     }
 
     @Test
     public void parseCommand_add() throws Exception {
         List<Person> patients = model.getFilteredPersonList();
         Person person = new PersonBuilder().build();
-        AddCommand command = (AddCommand) parser.parseCommand(PersonUtil.getAddCommand(person), patients);
+        AddCommand command = (AddCommand) parser.parseCommand(PersonUtil.getAddCommand(person));
         assertEquals(new AddCommand(person), command);
     }
 
     @Test
     public void parseCommand_clear() throws Exception {
-        List<Person> patients = model.getFilteredPersonList();
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD, patients) instanceof ClearCommand);
-        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3", patients) instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD) instanceof ClearCommand);
+        assertTrue(parser.parseCommand(ClearCommand.COMMAND_WORD + " 3") instanceof ClearCommand);
     }
 
     @Test
     public void parseCommand_delete() throws Exception {
-        List<Person> patients = model.getFilteredPersonList();
         DeleteCommand command = (DeleteCommand) parser.parseCommand(
-                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased(), patients);
+                DeleteCommand.COMMAND_WORD + " " + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
     }
 
     @Test
     public void parseCommand_edit() throws Exception {
-        List<Person> patients = model.getFilteredPersonList();
         Person person = new PersonBuilder().build();
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " "
-                + PersonUtil.getEditPersonDescriptorDetails(descriptor), patients);
+                + PersonUtil.getEditPersonDescriptorDetails(descriptor));
         assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
     }
 
     @Test
     public void parseCommand_exit() throws Exception {
-        List<Person> patients = model.getFilteredPersonList();
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD, patients) instanceof ExitCommand);
-        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3", patients) instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD) instanceof ExitCommand);
+        assertTrue(parser.parseCommand(ExitCommand.COMMAND_WORD + " 3") instanceof ExitCommand);
     }
 
     @Test
     public void parseCommand_find() throws Exception {
-        List<Person> patients = model.getFilteredPersonList();
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
-                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")),
-                patients);
+                FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
     }
 
     @Test
     public void parseCommand_help() throws Exception {
-        List<Person> patients = model.getFilteredPersonList();
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD, patients) instanceof HelpCommand);
-        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3", patients) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD) instanceof HelpCommand);
+        assertTrue(parser.parseCommand(HelpCommand.COMMAND_WORD + " 3") instanceof HelpCommand);
     }
 
     @Test
     public void parseCommand_list() throws Exception {
-        List<Person> patients = model.getFilteredPersonList();
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD, patients) instanceof ListCommand);
-        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3", patients) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
     }
 
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
-        List<Person> patients = model.getFilteredPersonList();
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand("", patients));
+            -> parser.parseCommand(""));
     }
 
     @Test
     public void parseCommand_unknownCommand_throwsParseException() {
-        List<Person> patients = model.getFilteredPersonList();
         assertThrows(ParseException.class, MESSAGE_UNKNOWN_COMMAND, () ->
-                parser.parseCommand("unknownCommand", patients));
+                parser.parseCommand("unknownCommand"));
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -43,7 +43,9 @@ public class AddressBookParserTest {
     @BeforeEach
     public void setUp() {
         model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
-        parser = new AddressBookParser(model.getFilteredPersonList());
+        parser = new AddressBookParser(
+                model.getAddressBook().getPersonList(),
+                model.getAppointmentList().getAppointmentList());
     }
 
     @Test


### PR DESCRIPTION
Fixes: #39

### Describe your changes
Introduces the following validations
1. Date and time cannot be in the past
2. Specific error messages are now shown according to your input mistakes. E.g. failed datetime -> "Your date time is wrong, please use the following format..."
3. Non-existent IDs when adding appointments are validated and shown the appropriate error message
