### PR TITLE
Fix CodeCov Icon

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@
 # CogniCare
 
 [![CI Status](https://github.com/AY2324S2-CS2103-F08-2/tp/workflows/Java%20CI/badge.svg)](https://github.com/AY2324S2-CS2103-F08-2/tp/actions)
-[![codecov](https://codecov.io/gh/nus-cs2103-AY2324S2/tp/graph/badge.svg?token=PBBJNYE8U5)](https://codecov.io/gh/nus-cs2103-AY2324S2/tp)
+[![codecov](https://codecov.io/gh/AY2324S2-CS2103-F08-2/tp/graph/badge.svg?token=PBBJNYE8U5)](https://codecov.io/gh/AY2324S2-CS2103-F08-2/tp)
 
 ![Ui](images/Ui.png)
 


### PR DESCRIPTION
Fixes: #93 
Fixes: #125

For some reason the Badge icon in the `index.md` file is not updated.

For your verification - please, @tankh99.