### PR TITLE
Improve UI to display all tags

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -130,7 +130,7 @@ public class MainWindow extends UiPart<Stage> {
         CommandBox commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
 
-        PatientTagViewer patientTagViewer1 = new PatientTagViewer();
+        PatientTagViewer patientTagViewer1 = new PatientTagViewer(logic.getPatientList());
         patientTagViewer.getChildren().add(patientTagViewer1.getRoot());
     }
 

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -9,6 +9,7 @@ import javafx.scene.control.TextInputControl;
 import javafx.scene.input.KeyCombination;
 import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.StackPane;
+import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
@@ -49,6 +50,9 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane statusbarPlaceholder;
+
+    @FXML
+    private VBox patientTagViewer;
 
     /**
      * Creates a {@code MainWindow} with the given {@code Stage} and {@code Logic}.
@@ -125,6 +129,9 @@ public class MainWindow extends UiPart<Stage> {
 
         CommandBox commandBox = new CommandBox(this::executeCommand);
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());
+
+        PatientTagViewer patientTagViewer1 = new PatientTagViewer();
+        patientTagViewer.getChildren().add(patientTagViewer1.getRoot());
     }
 
     /**

--- a/src/main/java/seedu/address/ui/PatientTagViewer.java
+++ b/src/main/java/seedu/address/ui/PatientTagViewer.java
@@ -6,14 +6,21 @@ import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.Region;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyPatientList;
+
+import java.util.Comparator;
+import java.util.HashMap;
 
 public class PatientTagViewer extends UiPart<Region> {
     private static final String FXML = "PatientTagViewer.fxml";
 
+    public static final int MAX_TAGS_TO_BE_DISPLAYED = 20;
+
     @FXML
     private FlowPane tags;
 
-    public PatientTagViewer() {
+    public PatientTagViewer(ReadOnlyPatientList model) {
         super(FXML);
 
         // Set horizontal and vertical gaps
@@ -21,24 +28,34 @@ public class PatientTagViewer extends UiPart<Region> {
         tags.setVgap(10); // Set the vertical gap between children
 
 
-        // TODO: Limit to 10
-        addStyledLabel("depression");
-        addStyledLabel("anxiety");
-        addStyledLabel("substance abuse");
-        addStyledLabel("PTSD");
-        addStyledLabel("OCD");
-        addStyledLabel("bipolar disorder");
-        addStyledLabel("schizophrenia");
-        addStyledLabel("ADHD");
-        addStyledLabel("eating disorders");
-        addStyledLabel("insomnia");
+
+        HashMap<String, Integer> tagInfo = new HashMap<>();
+
+        model.getPersonList().stream().forEach(person -> {
+            person.getTags().stream().forEach(tag -> {
+                tagInfo.put(tag.tagName, tagInfo.getOrDefault(tag.tagName, 0) + 1);
+            });
+        });
+
+
+
+        tagInfo.entrySet().stream()
+                // Sort by value size in descending order
+                // Credits: ChatGPT "Stream sort by value size"
+                .sorted(Comparator.comparingInt(entry -> -entry.getValue()))
+                // Limit length to prevent malicious users.
+                .limit(MAX_TAGS_TO_BE_DISPLAYED).forEach(tag -> {
+                    addStyledLabel(tag.getKey() + " (" + tag.getValue() + ")");
+                }
+        );
     }
+
+
 
 
     // Method to add styled label
     private void addStyledLabel(String labelText) {
         Label label = new Label(labelText);
-        label.getStyleClass().add("cell_small_label"); // Add a CSS class for styling
         tags.getChildren().add(label);
     }
 }

--- a/src/main/java/seedu/address/ui/PatientTagViewer.java
+++ b/src/main/java/seedu/address/ui/PatientTagViewer.java
@@ -1,11 +1,44 @@
 package seedu.address.ui;
 
+import javafx.fxml.FXML;
+
+
+import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.Region;
 
 public class PatientTagViewer extends UiPart<Region> {
     private static final String FXML = "PatientTagViewer.fxml";
 
+    @FXML
+    private FlowPane tags;
+
     public PatientTagViewer() {
         super(FXML);
+
+        // Set horizontal and vertical gaps
+        tags.setHgap(10); // Set the horizontal gap between children
+        tags.setVgap(10); // Set the vertical gap between children
+
+
+        // TODO: Limit to 10
+        addStyledLabel("depression");
+        addStyledLabel("anxiety");
+        addStyledLabel("substance abuse");
+        addStyledLabel("PTSD");
+        addStyledLabel("OCD");
+        addStyledLabel("bipolar disorder");
+        addStyledLabel("schizophrenia");
+        addStyledLabel("ADHD");
+        addStyledLabel("eating disorders");
+        addStyledLabel("insomnia");
+    }
+
+
+    // Method to add styled label
+    private void addStyledLabel(String labelText) {
+        Label label = new Label(labelText);
+        label.getStyleClass().add("cell_small_label"); // Add a CSS class for styling
+        tags.getChildren().add(label);
     }
 }

--- a/src/main/java/seedu/address/ui/PatientTagViewer.java
+++ b/src/main/java/seedu/address/ui/PatientTagViewer.java
@@ -1,0 +1,11 @@
+package seedu.address.ui;
+
+import javafx.scene.layout.Region;
+
+public class PatientTagViewer extends UiPart<Region> {
+    private static final String FXML = "PatientTagViewer.fxml";
+
+    public PatientTagViewer() {
+        super(FXML);
+    }
+}

--- a/src/main/java/seedu/address/ui/PatientTagViewer.java
+++ b/src/main/java/seedu/address/ui/PatientTagViewer.java
@@ -1,42 +1,41 @@
 package seedu.address.ui;
 
-import javafx.fxml.FXML;
-
-
-import javafx.scene.control.Label;
-import javafx.scene.layout.FlowPane;
-import javafx.scene.layout.Region;
-import seedu.address.model.Model;
-import seedu.address.model.ReadOnlyPatientList;
-
 import java.util.Comparator;
 import java.util.HashMap;
 
-public class PatientTagViewer extends UiPart<Region> {
-    private static final String FXML = "PatientTagViewer.fxml";
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.FlowPane;
+import javafx.scene.layout.Region;
+import seedu.address.model.ReadOnlyPatientList;
 
+/**
+ * Represents a class that displays all patient tags in main UI.
+ */
+public class PatientTagViewer extends UiPart<Region> {
     public static final int MAX_TAGS_TO_BE_DISPLAYED = 20;
+
+    private static final String FXML = "PatientTagViewer.fxml";
 
     @FXML
     private FlowPane tags;
 
+    /**
+     * Renders the Patient alias as  Labels
+     * @param model which contains all patient information.
+     */
     public PatientTagViewer(ReadOnlyPatientList model) {
         super(FXML);
 
-        // Set horizontal and vertical gaps
-        tags.setHgap(10); // Set the horizontal gap between children
-        tags.setVgap(10); // Set the vertical gap between children
-
-
-
+        // Create as a HashMap to store the tagInformation as key and count as value
         HashMap<String, Integer> tagInfo = new HashMap<>();
 
+        // Iterate all person, and their tag to count how many occurrence.
         model.getPersonList().stream().forEach(person -> {
             person.getTags().stream().forEach(tag -> {
                 tagInfo.put(tag.tagName, tagInfo.getOrDefault(tag.tagName, 0) + 1);
             });
         });
-
 
 
         tagInfo.entrySet().stream()
@@ -45,7 +44,7 @@ public class PatientTagViewer extends UiPart<Region> {
                 .sorted(Comparator.comparingInt(entry -> -entry.getValue()))
                 // Limit length to prevent malicious users.
                 .limit(MAX_TAGS_TO_BE_DISPLAYED).forEach(tag -> {
-                    addStyledLabel(tag.getKey() + " (" + tag.getValue() + ")");
+                    addLabel(tag.getKey() + " (" + tag.getValue() + ")");
                 }
         );
     }
@@ -53,8 +52,7 @@ public class PatientTagViewer extends UiPart<Region> {
 
 
 
-    // Method to add styled label
-    private void addStyledLabel(String labelText) {
+    private void addLabel(String labelText) {
         Label label = new Label(labelText);
         tags.getChildren().add(label);
     }

--- a/src/main/java/seedu/address/ui/PatientTagViewer.java
+++ b/src/main/java/seedu/address/ui/PatientTagViewer.java
@@ -3,11 +3,14 @@ package seedu.address.ui;
 import java.util.Comparator;
 import java.util.HashMap;
 
+import javafx.collections.ListChangeListener;
+import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.Region;
 import seedu.address.model.ReadOnlyPatientList;
+import seedu.address.model.patient.Patient;
 
 /**
  * Represents a class that displays all patient tags in main UI.
@@ -20,19 +23,34 @@ public class PatientTagViewer extends UiPart<Region> {
     @FXML
     private FlowPane tags;
 
+    private final ObservableList<Patient> patientList;
+
     /**
      * Renders the Patient alias as  Labels
      * @param model which contains all patient information.
      */
     public PatientTagViewer(ReadOnlyPatientList model) {
         super(FXML);
+        patientList = model.getPersonList();
+
+        // Add listener to PersonList.
+        // Inspired by: https://stackoverflow.com/questions/23335522/
+        patientList.addListener((ListChangeListener.Change<? extends Patient> change) -> updateTags());
+
+        updateTags();
+    }
+
+    private void updateTags() {
+        // Clear existing tags
+        tags.getChildren().clear();
 
         // Create as a HashMap to store the tagInformation as key and count as value
         HashMap<String, Integer> tagInfo = new HashMap<>();
 
         // Iterate all person, and their tag to count how many occurrence.
-        model.getPersonList().stream().forEach(person -> {
+        patientList.stream().forEach(person -> {
             person.getTags().stream().forEach(tag -> {
+                // If there is a value, increment it, otherwise we start from 1.
                 tagInfo.put(tag.tagName, tagInfo.getOrDefault(tag.tagName, 0) + 1);
             });
         });
@@ -45,12 +63,8 @@ public class PatientTagViewer extends UiPart<Region> {
                 // Limit length to prevent malicious users.
                 .limit(MAX_TAGS_TO_BE_DISPLAYED).forEach(tag -> {
                     addLabel(tag.getKey() + " (" + tag.getValue() + ")");
-                }
-        );
+                });
     }
-
-
-
 
     private void addLabel(String labelText) {
         Label label = new Label(labelText);

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -47,7 +47,6 @@ public class PersonCard extends UiPart<Region> {
     public PersonCard(Patient patient, int displayedIndex) {
         super(FXML);
         this.patient = patient;
-        //id.setText(displayedIndex + ". ");
         id.setText(patient.getSid() + ". ");
         name.setText(patient.getName().fullName);
         phone.setText(patient.getPhone().value);

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -12,48 +12,52 @@
 
 <fx:root type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1"
          title="CogniCare" minWidth="450" minHeight="600" onCloseRequest="#handleExit">
-  <icons>
-    <Image url="@/images/address_book_32.png" />
-  </icons>
-  <scene>
-    <Scene>
-      <stylesheets>
-        <URL value="@DarkTheme.css" />
-        <URL value="@Extensions.css" />
-      </stylesheets>
+    <icons>
+        <Image url="@/images/address_book_32.png"/>
+    </icons>
+    <scene>
+        <Scene>
+            <stylesheets>
+                <URL value="@DarkTheme.css"/>
+                <URL value="@Extensions.css"/>
+            </stylesheets>
 
-      <VBox>
-        <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
-          <Menu mnemonicParsing="false" text="File">
-            <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit" />
-          </Menu>
-          <Menu mnemonicParsing="false" text="Help">
-            <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
-          </Menu>
-        </MenuBar>
+            <VBox>
+                <MenuBar fx:id="menuBar" VBox.vgrow="NEVER">
+                    <Menu mnemonicParsing="false" text="File">
+                        <MenuItem mnemonicParsing="false" onAction="#handleExit" text="Exit"/>
+                    </Menu>
+                    <Menu mnemonicParsing="false" text="Help">
+                        <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help"/>
+                    </Menu>
+                </MenuBar>
 
-        <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
-          <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
-          </padding>
-        </StackPane>
+                <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
+                    <padding>
+                        <Insets top="5" right="10" bottom="5" left="10"/>
+                    </padding>
+                </StackPane>
 
-        <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
-                   minHeight="100" prefHeight="100" maxHeight="100">
-          <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
-          </padding>
-        </StackPane>
 
-        <VBox styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
-          <padding>
-            <Insets top="10" right="10" bottom="10" left="10" />
-          </padding>
-          <StackPane fx:id="listPanelPlaceholder" VBox.vgrow="ALWAYS"/>
-        </VBox>
+                <StackPane VBox.vgrow="NEVER" fx:id="resultDisplayPlaceholder" styleClass="pane-with-border"
+                           minHeight="100" prefHeight="100" maxHeight="100">
+                    <padding>
+                        <Insets top="5" right="10" bottom="5" left="10"/>
+                    </padding>
+                </StackPane>
 
-        <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
-      </VBox>
-    </Scene>
-  </scene>
+
+                <VBox fx:id="patientTagViewer"></VBox>
+
+                <VBox styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
+                    <padding>
+                        <Insets top="10" right="10" bottom="10" left="10"/>
+                    </padding>
+                    <StackPane fx:id="listPanelPlaceholder" VBox.vgrow="ALWAYS"/>
+                </VBox>
+
+                <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER"/>
+            </VBox>
+        </Scene>
+    </scene>
 </fx:root>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -47,7 +47,12 @@
                 </StackPane>
 
 
-                <VBox fx:id="patientTagViewer"></VBox>
+                <VBox fx:id="patientTagViewer" prefHeight="24" styleClass="pane-with-border">
+                    <padding>
+                        <Insets top="5" right="10" bottom="5" left="10"/>
+                    </padding>
+                </VBox>
+
 
                 <VBox styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
                     <padding>

--- a/src/main/resources/view/PatientTagViewer.fxml
+++ b/src/main/resources/view/PatientTagViewer.fxml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?import javafx.scene.layout.FlowPane?>
+
+<?import javafx.scene.text.Text?>
+<FlowPane fx:id="allPatientTags" xmlns:fx="http://javafx.com/fxml">
+</FlowPane>
+

--- a/src/main/resources/view/PatientTagViewer.fxml
+++ b/src/main/resources/view/PatientTagViewer.fxml
@@ -2,6 +2,6 @@
 <?import javafx.scene.layout.FlowPane?>
 
 <?import javafx.scene.text.Text?>
-<FlowPane fx:id="allPatientTags" xmlns:fx="http://javafx.com/fxml">
+<FlowPane fx:id="tags" xmlns:fx="http://javafx.com/fxml">
 </FlowPane>
 

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -27,8 +27,8 @@
         </Label>
         <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
       </HBox>
-      <FlowPane fx:id="tags" />
-      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+      <FlowPane fx:id="tags" />      <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+
       <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
     </VBox>
   </GridPane>


### PR DESCRIPTION
Fixes: #182 

Displays all tags in a easy to read format with auto update, and count

<img width="1109" alt="image" src="https://github.com/AY2324S2-CS2103-F08-2/tp/assets/49815108/0283038c-6848-475a-aebd-8c7a699966a3">
