### PR TITLE
Fix null pointer exception in command history

### DIFF
--- a/src/main/java/seedu/address/commons/core/CommandHistory.java
+++ b/src/main/java/seedu/address/commons/core/CommandHistory.java
@@ -11,7 +11,7 @@ import seedu.address.commons.util.AudioUtil;
  */
 public class CommandHistory {
     private final List<String> commandHistory;
-    private int currentCommandIndex = -1;
+    private int currentCommandIndex = 0;
 
     /**
      * Initializes the command history with an empty string as the first command.


### PR DESCRIPTION
Fixes: #323 

### Describe your changes
Set default index to 0 instead of -1