### PR TITLE
Update activity diagrams

### DIFF
--- a/docs/diagrams/AddAppointmentActivityDiagram.puml
+++ b/docs/diagrams/AddAppointmentActivityDiagram.puml
@@ -1,35 +1,31 @@
 @startuml
-!include style.puml
-skinparam arrowThickness 1.1
-skinparam arrowColor LOGIC_COLOR_T4
-skinparam classBackgroundColor LOGIC_COLOR
 
 start
  :User enters add appointment command;
- if (missing parameters?) then ([no])
+ if () then ([else] )
+    : CogniCare throws a Parse Exception;
+    : Error message is displayed;
 
-    if (all parameters entered correctly?) then ([no])
+ else ( [is valid command format] )
+
+    if () then ([else] )
         : CogniCare throws a Parse Exception;
         : Error message is displayed;
 
-    else ([yes])
+    else ( [prefix(es) are valid])
         :Create a new appointment object;
         :Return a new AddAppointmentCommand;
 
-        if (new appointment is valid?) then ([no])
+        if () then ([else] )
             :CogniCare throws a Command Exception;
             :Error message is displayed;
 
-        else ([yes])
+        else ( [new appointment is valid])
             :Appointment is added to CogniCare;
             :Success message is displayed;
         endif
 
     endif
-
- else ([yes])
-    : CogniCare throws a Parse Exception;
-    : Error message is displayed;
 
  endif
 stop

--- a/docs/diagrams/DeleteAppointmentActivityDiagram.puml
+++ b/docs/diagrams/DeleteAppointmentActivityDiagram.puml
@@ -1,31 +1,27 @@
 @startuml
-!include style.puml
-skinparam arrowThickness 1.1
-skinparam arrowColor LOGIC_COLOR_T4
-skinparam classBackgroundColor LOGIC_COLOR
 
 start
  :User enters the delete appointment command;
- if (missing appointment index?) then ([no])
+ if () then ([else] )
 
     : Return new DeleteAppointmentCommand;
-            if (is valid index?) then ([no])
+            if () then ([else] )
                 : CogniCare throws a Command Exception;
                 : Error message is displayed;
 
-            else ([yes])
+            else ( [valid index])
 
-                if (appointment is present) then ([no])
+                if () then ([else] )
                     : CogniCare throws a Command Exception;
                     : Error message is displayed;
-                else ([yes])
+                else ( [appointment is present])
                     : CogniCare deletes the appointment;
                     : Success message is displayed;
                 endif
 
             endif
 
- else ([yes])
+ else ( [missing appointment index])
     : CogniCare throws a Parse Exception;
     : Error message is displayed;
 

--- a/docs/diagrams/QueryAppointmentActivityDiagram.puml
+++ b/docs/diagrams/QueryAppointmentActivityDiagram.puml
@@ -22,7 +22,8 @@ else ( [no duplicate parameters])
                 :CogniCare throws a Parse Exception;
                 :Error message is displayed;
             else( [prefix(es) are valid])
-                :Filter list by prefix(es) \nand return filtered list;
+                :Filter list by prefix(es);
+                :Return filtered appointments;
             endif
         endif
     endif

--- a/docs/diagrams/QueryAppointmentActivityDiagram.puml
+++ b/docs/diagrams/QueryAppointmentActivityDiagram.puml
@@ -1,27 +1,27 @@
 @startuml
 
 :User enters query command;
-if (no duplicate parameters) then ([no])
+if () then ([else] )
     :CogniCare throws a Parse Exception;
     :Error message is displayed;
 
-else ([yes])
-    if (is valid command format) then ([no])
+else ( [no duplicate parameters])
+    if () then ([else] )
         :CogniCare throws a Parse Exception;
         :Error message is displayed;
-    else ([yes])
-        if (prefix(es) are specified) then([no])
-            if(preamble is empty) then([no])
+    else ( [is valid command format])
+        if () then([else] )
+            if() then([else] )
                 :CogniCare throws a Parse Exception;
                 :Error message is displayed;
-            else([yes])
+            else( [preamble is empty])
                 :Return all appointments;
             endif
-        else([no])
-            if (prefix(es) are valid) then([no])
+        else( [prefix(es) are specified])
+            if () then([else] )
                 :CogniCare throws a Parse Exception;
                 :Error message is displayed;
-            else([yes])
+            else( [prefix(es) are valid])
                 :Filter list by prefix(es) \nand return filtered list;
             endif
         endif


### PR DESCRIPTION
Fixes:

### Describe your changes
Update activity diagrams to follow convention. Else (no) condition is on the left and the condition is on the true branch. Have moved the conditions out of the diamond following the style in the `CommitActivityDiagram`


Add appointment activity diagram
![image](https://github.com/AY2324S2-CS2103-F08-2/tp/assets/86278971/db55ad3b-469d-49e0-8286-97f4d35410f7)

Query appointment activity diagram
![image](https://github.com/AY2324S2-CS2103-F08-2/tp/assets/86278971/0e44e546-bcfe-4af4-adeb-f3d59cd0be73)

Delete appointment activity diagram
![image](https://github.com/AY2324S2-CS2103-F08-2/tp/assets/86278971/db9734dc-1646-4465-926d-df89dd5c746b)

